### PR TITLE
Fix 02 solution / Tip for 03 exercise

### DIFF
--- a/src/exercises-final/02.extra-1.js
+++ b/src/exercises-final/02.extra-1.js
@@ -8,7 +8,7 @@ function Toggle({children}) {
   const [on, setOn] = React.useState(false)
   const toggle = () => setOn(!on)
   return React.Children.map(children, child => {
-    return typeof child === 'string'
+    return typeof child.type === 'string'
       ? child
       : React.cloneElement(child, {on, toggle})
   })

--- a/src/exercises/01.js
+++ b/src/exercises/01.js
@@ -30,7 +30,7 @@ function UserProvider({children}) {
 // which retrieves the context value via React.useContext, then people can use
 // your custom hook. If you want to try that, then go ahead and put it here.
 
-// This is a utility function which accepts the reduer's dispatch function
+// This is a utility function which accepts the reducer's dispatch function
 // as well as the user and any updates. It's responsible for interacting with
 // the userClient and the dispatch.
 async function updateUser(dispatch, user, updates) {

--- a/src/exercises/03.js
+++ b/src/exercises/03.js
@@ -22,13 +22,15 @@ function Toggle({onToggle, children}) {
 // 🐨 we'll still get the children from props (as it's passed to us by the
 // developers using our component), but we'll get `on` implicitely from
 // ToggleContext now
+// 🦉 You can create a helper method to retrieve the context here. Thanks to that,
+// your context won't be exposed to the user
 // 💰 `const context = useContext(ToggleContext)`
 // 📜 https://reactjs.org/docs/hooks-reference.html#usecontext
 function ToggleOn({on, children}) {
   return on ? children : null
 }
 
-// 🐨 do the same thing to this that you did to the On component
+// 🐨 do the same thing to this that you did to the ToggleOn component
 function ToggleOff({on, children}) {
   return on ? null : children
 }


### PR DESCRIPTION
This PR is intended to contribute in 2 sections:

Fix a small bug in the 02 exercise solution

Make cleaner what you have to do in the 03 exercise.

Regarding the second point, it led me into confusion the fact that the tips to do are outside from the methods, meanwhile, for the first method they are inside. When I got into there, automatically I assimilated it had to be a helper method, because wasn't pointing it inside the method itself. Once I created the method, I moved into the ToggleOff and read that I had to apply the same as On, which lead me into more confusion, and then realized that wasn't necessary a helper method to achieve the exercise.

Since it's a very small thing, I put both fixes in the same PR. The other alternative I would suggest you, in case you don't like this owl here, would be to put the koala inside the method ( at least for ToggleOn).
👍 I think that's all :)