### PR TITLE
Remove non-existing increment and decrement export

### DIFF
--- a/src/exercise/01.md
+++ b/src/exercise/01.md
@@ -39,12 +39,12 @@ function useCounter() {
   return context
 }
 
-export {CounterProvider, useCounter, increment, decrement}
+export {CounterProvider, useCounter}
 ```
 
 ```javascript
 // src/screens/counter.js
-import {useCounter, increment, decrement} from 'context/counter'
+import {useCounter} from 'context/counter'
 
 function Counter() {
   const [state, dispatch] = useCounter()


### PR DESCRIPTION
Remove `increment`/`decrement` from `import` and `export` in the first example from **Context Module Functions**.