### PR TITLE
simplify code conrtibutions by fully automating the dev environment.

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,16 @@
+tasks:
+  - name: Dev Server
+    init: npm install && gp sync-done install
+    command: npm start
+  - name: Test Covrage
+    init: gp sync-await install
+    command: npm test -- --watchAll
+    openMode: split-right
+
+ports: 
+  - port: 3000
+    onOpen: open-preview
+
+vscode:
+  extensions:
+    - esbenp.prettier-vscode@5.7.1:4Zx39KyQMoIz7x94PSmDmQ==

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 [![AppVeyor Build Status][win-build-badge]][win-build]
 [![GPL 3.0 License][license-badge]][license]
 [![Code of Conduct][coc-badge]][coc]
+[![Gitpod Ready-to-Code][gitpod-badge]][gitpod]
 <!-- prettier-ignore-end -->
 
 ## Prerequisites
@@ -56,6 +57,12 @@ variable and how to fix it here for [windows][win-path] or
 [mac/linux][mac-path].
 
 ## Setup
+
+### Online one-click setup
+
+You can either follow the below instructions for the local setup or use Gitpod(An Online Open Source VS Code like IDE) for playing around with the code or for working on issues and making PRs to this repo. With a single click it will automatically clone the repo, install all the dependencies and run `npm start` and `npm test`(in watch mode) in isolated Linux terminals so that you can start hacking around without any friction. 
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
 
 After you've made sure to have the correct things (and versions) installed, you
 should be able to just run a few commands to get set up:
@@ -210,4 +217,6 @@ Thank you! https://kcd.im/arp-ws-feedback
 [issue]: https://github.com/kentcdodds/advanced-react-patterns/issues/new
 [win-build-badge]: https://img.shields.io/appveyor/ci/kentcdodds/advanced-react-patterns.svg?style=flat-square&logo=appveyor
 [win-build]: https://ci.appveyor.com/project/kentcdodds/advanced-react-patterns
+[gitpod-badge]: https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod
+[gitpod]: https://gitpod.io/from-referrer/
 <!-- prettier-ignore-end -->


### PR DESCRIPTION
Hi. 

I work for Gitpod(an online Open Source VS Code like IDE which is free for Open Source) and we're currently on a mission to simplify contributors/maintainers onboarding for cool Open Source projects. 

A lot of projects out there are already using Gitpod to simplify contributors/maintainers onboarding experience some of them are:

 -  https://github.com/freeCodeCamp/freeCodeCamp
 -  https://github.com/facebook/docusaurus
 -  https://github.com/mozilla/pdf.js/
-  https://github.com/gatsbyjs/gatsby/
-  https://github.com/mobxjs/mobx/

You can find a brief list of them at https://contribute.dev

![image](https://user-images.githubusercontent.com/46004116/95134600-9a3d9b80-077c-11eb-89ea-f9a90423e678.png)

This Pr adds Gitpod config to the repo to fully automate the dev setup for this project i.e with this config anyone interested in contributing to this project would be able to start a workspace where it will automatically:

- clone this repo.
- install all the dependencies.
- run `npm start` and `npm test`(in watch mode) in separate Linux terminals.

This way anyone interested in contributing can start straight away without any friction.

You can give it a try on my fork of the repo via the following link: 

https://gitpod.io/#https://github.com/nisarhassan12/advanced-react-patterns

This is how it looks:

![image](https://user-images.githubusercontent.com/46004116/95237241-6072a080-0821-11eb-8939-21a3654c5b35.png)
