### PR TITLE
Change variable name to clarify warning function

### DIFF
--- a/src/exercise/06.md
+++ b/src/exercise/06.md
@@ -102,7 +102,7 @@ other extra credits will handle the other cases).
 💰 You can use the `warning` package to do this:
 
 ```javascript
-warning(shouldWarn, 'Warning message')
+warning(doNotWarn, 'Warning message')
 
 // so:
 warning(false, 'This will warn')


### PR DESCRIPTION
the name `shouldWarn` makes it sound like passing true would create a warning but in fact, passing something that is `truthy` does not create a warning while a `falsey` value does show the warning. Change the name to try to make this more clear