### PR TITLE
Suggestion: show component name instead of hook name in warnings

### DIFF
--- a/src/final/06.extra-3.js
+++ b/src/final/06.extra-3.js
@@ -81,6 +81,7 @@ function useToggle({
   onChange,
   on: controlledOn,
   readOnly = false,
+  componentName = 'Toggle',
 } = {}) {
   const {current: initialState} = React.useRef({on: initialOn})
   const [state, dispatch] = React.useReducer(reducer, initialState)
@@ -88,11 +89,11 @@ function useToggle({
   const onIsControlled = controlledOn != null
   const on = onIsControlled ? controlledOn : state.on
 
-  useControlledSwitchWarning(controlledOn, 'on', 'useToggle')
+  useControlledSwitchWarning(controlledOn, 'on', componentName)
   useOnChangeReadOnlyWarning(
     controlledOn,
     'on',
-    'useToggle',
+    componentName,
     Boolean(onChange),
     readOnly,
     'readOnly',
@@ -140,6 +141,7 @@ function Toggle({on: controlledOn, onChange, readOnly}) {
     on: controlledOn,
     onChange,
     readOnly,
+    componentName: 'Toggle',
   })
   const props = getTogglerProps({on})
   return <Switch {...props} />

--- a/src/final/06.extra-4.js
+++ b/src/final/06.extra-4.js
@@ -81,18 +81,19 @@ function useToggle({
   onChange,
   on: controlledOn,
   readOnly = false,
+  componentName = 'Toggle',
 } = {}) {
   const {current: initialState} = React.useRef({on: initialOn})
   const [state, dispatch] = React.useReducer(reducer, initialState)
 
   if (process.env.NODE_ENV !== 'production') {
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    useControlledSwitchWarning(controlledOn, 'on', 'useToggle')
+    useControlledSwitchWarning(controlledOn, 'on', componentName)
     // eslint-disable-next-line react-hooks/rules-of-hooks
     useOnChangeReadOnlyWarning(
       controlledOn,
       'on',
-      'useToggle',
+      componentName,
       Boolean(onChange),
       readOnly,
       'readOnly',
@@ -144,6 +145,7 @@ function Toggle({on: controlledOn, onChange, readOnly}) {
     on: controlledOn,
     onChange,
     readOnly,
+    componentName: 'Toggle',
   })
   const props = getTogglerProps({on})
   return <Switch {...props} />


### PR DESCRIPTION
Currently, the warnings show the hook name, `useToggle` like below and I'm afraid that this could confuse users who don't know how the component is implemented internally.

```
Warning: `useToggle` is changing from uncontrolled to be controlled. Components should not switch from uncontrolled to controlled (or vice versa). Decide between using a controlled or uncontrolled `useToggle` for the lifetime of the component. Check the `on` prop.
```

So, I'd like to suggest showing the component name, `Toggle` instead. I think this will make the warnings more helpful and align more with what React does for native HTML elements.

```
Warning: `Toggle` is changing from uncontrolled to be controlled. Components should not switch from uncontrolled to controlled (or vice versa). Decide between using a controlled or uncontrolled `Toggle` for the lifetime of the component. Check the `on` prop. 
```