### PR TITLE
Fix example for real-life usage for lesson 2

### DIFF
--- a/src/exercise/02.md
+++ b/src/exercise/02.md
@@ -37,7 +37,7 @@ compound components come in really handy!
 
 **Real World Projects that use this pattern:**
 
-- [`@reach/tooltip`](https://reacttraining.com/reach-ui/tooltip)
+- [`@reach/tabs`](https://reacttraining.com/reach-ui/tabs)
 - Actually most of [Reach UI](https://reacttraining.com/reach-ui) implements
   this pattern
 


### PR DESCRIPTION
I could not find examples of the pattern (`React.Children.map` and `React.cloneElement`) in [`@reach/tooltip`](https://github.com/reach/reach-ui/blob/main/packages/tooltip/src/index.tsx). This was very confusing during the exercise.

In comparison, `@reach/tabs` uses that pattern in [its source code](https://github.com/reach/reach-ui/blob/97b32791ce33f822f6bc9f07f6cebfb343d8032d/packages/tabs/src/index.tsx#L383).