### PR TITLE
Update 06.js, add an extra line of instructions

### DIFF
--- a/src/exercise/06.js
+++ b/src/exercise/06.js
@@ -31,6 +31,7 @@ function useToggle({
   // 🐨 add an `onChange` prop.
   // 🐨 add an `on` option here
   // 💰 you can alias it to `controlledOn` to avoid "variable shadowing."
+  // 🐨 default it to `null` so you can check whether or not `on` is controlled
 } = {}) {
   const {current: initialState} = React.useRef({on: initialOn})
   const [state, dispatch] = React.useReducer(reducer, initialState)


### PR DESCRIPTION
Unless I'm mistaken, you have to add the `on` prop as
```js
on: controlledOn = null
```
in order for the `null` check in defining `onIsControlled` to work

I think this should be explicit.