### PR TITLE
fix: Replace `controlledOn` with `on` in control props

### DIFF
--- a/src/exercise/06.js
+++ b/src/exercise/06.js
@@ -37,7 +37,7 @@ function useToggle({
   // 🐨 determine whether on is controlled and assign that to `onIsControlled`
   // 💰 `controlledOn != null`
 
-  // 🐨 Replace the next line with assigning `controlledOn` to `on` if
+  // 🐨 Replace the next line with `const on = ...` which should be `controlledOn` if
   // `onIsControlled`, otherwise, it should be `state.on`.
   const {on} = state
 

--- a/src/exercise/06.js
+++ b/src/exercise/06.js
@@ -37,7 +37,7 @@ function useToggle({
   // 🐨 determine whether on is controlled and assign that to `onIsControlled`
   // 💰 `controlledOn != null`
 
-  // 🐨 Replace the next line with assigning `on` to `controlledOn` if
+  // 🐨 Replace the next line with assigning `controlledOn` to `on` if
   // `onIsControlled`, otherwise, it should be `state.on`.
   const {on} = state
 


### PR DESCRIPTION
Hey! ✌️ 

I'm currently working on the control props and it was a bit confusing when I reach this part. 
The thing is that 🐨 (Kody the Koala) suggests to _"assigning `on` to `controlledOn`"_  and if we see the final solution I think this should be the other way around.

**SPOILER ALERT**
Final solution: 
`const on = onIsControlled ? controlledOn : state.on`
