### PR TITLE
Fix broken links to React Documentation

### DIFF
--- a/src/exercise/01.md
+++ b/src/exercise/01.md
@@ -190,8 +190,8 @@ I wouldn't recommend this all the time, but sometimes it can be a help!
 
 📜 If you need to review the context API, here are the docs:
 
-- https://reactjs.org/docs/context.html
-- https://reactjs.org/docs/hooks-reference.html#usecontext
+- [React Docs - Context](https://reactjs.org/docs/context.html)
+- [React Docs - useContext](https://reactjs.org/docs/hooks-reference.html#usecontext)
 
 🦉 Tip: You may notice that the context provider/consumers in React DevTools
 just display as `Context.Provider` and `Context.Consumer`. That doesn't do a


### PR DESCRIPTION
## What changed?

Before

<img width="1509" alt="image" src="https://user-images.githubusercontent.com/2466729/212340785-965da18f-0067-489a-bfd4-ed9ec4949f58.png">

After

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/2466729/212341404-796fef60-f465-4350-95b3-d947d0656b49.png">


## How did you test? 

- Ran it locally
- Clicked on links
