### PR TITLE
docs: input should grab the input slot

### DIFF
--- a/exercises/04.slots/01.problem.context/slots.tsx
+++ b/exercises/04.slots/01.problem.context/slots.tsx
@@ -14,6 +14,6 @@ export function Label(props: React.ComponentProps<'label'>) {
 }
 
 export function Input(props: React.ComponentProps<'input'>) {
-	// 🐨 get the props from useSlotProps for a slot called "label" and apply those to the input
+	// 🐨 get the props from useSlotProps for a slot called "input" and apply those to the input
 	return <input {...props} />
 }


### PR DESCRIPTION
The Input component has a comment saying it should pull in the "label" slot but it really should pull in the "input" slot.