### PR TITLE
feat(slot-prop): add slot type for TypeScript enforcement

### DIFF
--- a/exercises/04.slots/03.solution.prop/slots.tsx
+++ b/exercises/04.slots/03.solution.prop/slots.tsx
@@ -1,13 +1,20 @@
 import { createContext, use } from 'react'
 import { Switch as BaseSwitch } from '#shared/switch'
 
+export type SlotType =
+	| 'label'
+	| 'input'
+	| 'switch'
+	| 'text'
+	| 'onText'
+	| 'offText'
 type Slots = Record<string, Record<string, unknown>>
 export const SlotContext = createContext<Slots>({})
 
 function useSlotProps<Props>(
-	props: Props & { slot?: string },
-	defaultSlot?: string,
-): Props {
+	props: Props & { slot?: SlotType },
+	defaultSlot?: SlotType,
+): Props & { slot?: SlotType } {
 	const slot = props.slot ?? defaultSlot
 	if (!slot) return props
 
@@ -16,30 +23,32 @@ function useSlotProps<Props>(
 	// a more proper "mergeProps" function is in order here
 	// to handle things like merging event handlers better.
 	// we'll get to that a bit in a later exercise.
-	return { ...slots[slot], slot, ...props } as Props
+	return { ...slots[slot], slot, ...props } as Props & { slot?: SlotType }
 }
 
 export function Label(
-	props: React.ComponentProps<'label'> & { slot?: string },
+	props: React.ComponentProps<'label'> & { slot?: SlotType },
 ) {
 	props = useSlotProps(props, 'label')
 	return <label {...props} />
 }
 
 export function Input(
-	props: React.ComponentProps<'input'> & { slot?: string },
+	props: React.ComponentProps<'input'> & { slot?: SlotType },
 ) {
 	props = useSlotProps(props, 'input')
 	return <input {...props} />
 }
 
-export function Text(props: React.ComponentProps<'span'> & { slot?: string }) {
+export function Text(
+	props: React.ComponentProps<'span'> & { slot?: SlotType },
+) {
 	props = useSlotProps(props, 'text')
 	return <span {...props} />
 }
 
 type SwitchProps = Omit<React.ComponentProps<typeof BaseSwitch>, 'on'> & {
-	slot?: string
+	slot?: SlotType
 }
 export function Switch(props: SwitchProps) {
 	return (


### PR DESCRIPTION
Fun addition, but probably out of scope of the exercise.

Declare a type for TypeScript to enforce when a slot type is valid or not.

<img width="1207" alt="Screenshot 2024-04-10 at 3 08 28 PM" src="https://github.com/epicweb-dev/advanced-react-patterns/assets/1501490/d1adf1ac-a7b7-4308-ba8b-0fa57039cb4b">
